### PR TITLE
[NO-MERGE]fix: Consider `~/templates/_editorconfig`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: node_js
+node_js:
+  - '5'
+  - '4'
+  - '0.12'
+  - '0.10'
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: '4'
+    - node_js: '0.10'
+    - node_js: '0.12'

--- a/updatefile.js
+++ b/updatefile.js
@@ -2,11 +2,17 @@
 
 var os = require('os');
 var path = require('path');
+var fs = require('fs');
 var isValid = require('is-valid-app');
 
 module.exports = function(app, base, env) {
   if (!isValid(app, 'updater-editorconfig')) return;
-  var src = path.resolve.bind(path, __dirname, 'templates');
+  //var src = path.resolve.bind(path, __dirname, 'templates');
+
+  var src = path.join( os.homedir(), './templates', '_editorconfig');
+  if (!fs.existsSync( src )) {
+    src = path.join( __dirname, 'templates/_editorconfig');
+  }
 
   /**
    * Update or add an `.editorconfig` file in the current working directory.
@@ -19,7 +25,11 @@ module.exports = function(app, base, env) {
    */
 
   app.task('editorconfig', function() {
-    return app.copy(src('_editorconfig'), function(file) {
+
+    console.log('app.options.dest', app.options.dest);
+    console.log('app.cwd', app.cwd);
+
+    return app.copy( src, function(file) {
       file.basename = '.editorconfig';
       return app.options.dest || app.cwd;
     });

--- a/updatefile.js
+++ b/updatefile.js
@@ -7,7 +7,6 @@ var isValid = require('is-valid-app');
 
 module.exports = function(app, base, env) {
   if (!isValid(app, 'updater-editorconfig')) return;
-  //var src = path.resolve.bind(path, __dirname, 'templates');
 
   var src = path.join( os.homedir(), './templates', '_editorconfig');
   if (!fs.existsSync( src )) {
@@ -25,9 +24,6 @@ module.exports = function(app, base, env) {
    */
 
   app.task('editorconfig', function() {
-
-    console.log('app.options.dest', app.options.dest);
-    console.log('app.cwd', app.cwd);
 
     return app.copy( src, function(file) {
       file.basename = '.editorconfig';

--- a/updatefile.js
+++ b/updatefile.js
@@ -8,7 +8,7 @@ var isValid = require('is-valid-app');
 module.exports = function(app, base, env) {
   if (!isValid(app, 'updater-editorconfig')) return;
 
-  var src = path.join( os.homedir(), './templates', '_editorconfig');
+  var src = path.join( os.homedir(), './.templates', '_editorconfig');
   if (!fs.existsSync( src )) {
     src = path.join( __dirname, 'templates/_editorconfig');
   }


### PR DESCRIPTION
Fix to consider first _editorconfig in the global templates directory, then use `./templates/_editorconfig` as fallback.

See #1 
